### PR TITLE
chore: pre-commit, formatting, and documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+# To install the dependencies for this file:
+# 1) pip install pre-commit
+#   (really, "sudo python3 -m pip install pre-commit")
+#   (really, I've been carrying this boilerplate for years, but now it's all python3?)
+#
+# 2) pre-commit install --allow-missing-config
+#
+# yamllint checks this .pre-commit-config file as well
+---
+repos:
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.32.0
+    hooks:
+      - id: yamllint
+        args: [
+          '-d',
+          '{extends: relaxed, rules: {line-length: {max: 120}}}'
+        ]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: no-commit-to-branch
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.26.3
+    hooks:
+      - id: check-github-workflows
+      - id: check-renovate

--- a/numpy_test.py
+++ b/numpy_test.py
@@ -1,15 +1,43 @@
 import unittest
 import numpy
 
+
 class NumpyTestCase(unittest.TestCase):
+    """A basic check that sufficient numpy dependency is loaded to do basic work.
+
+    Numpy in past has cross-platform, cross-version, and wheel issues:
+    1. python setup assumes that the build platform is the run platform; this shows up when a
+        dependency tries to load some compiled/optimized component such as
+        `numpy.core._multiarray_umath`:
+    1.1. bulding on Mac, but running on linux, the loader looks for a
+        `site-packages/numpy/core/_multiarray_umath.cpython-39-linux.so` for there's only a
+        `site-packages/numpy/core/_multiarray_umath.cpython-39-darwin.so`
+    1.2. building on ARM HW but running on x86_64 linux, as was most of available AWS EC2, if
+        `_multiarray_umath.cpython-39-linux.so` was found, the ARM .so didn't provide what the
+        x86-64 `ldd` needed
+    1.3. building on python-3.11, but running on python-3.9 or vice-versa, the loader searching for
+        `_multiarray_umath.cpython-39-linux.so` would not see the `_multiarray_umath.cpython-311-linux.so`
+        provided during build
+    2. module authors don't often have the awareness for cross-platform, or the hardware to check
+    3. Python setup is a great place to hide idiosyncrasies of your setup; this hidden logic is
+        hard to make work in cross-platform, cross-arch, or cross-version, and it doesn't fail
+        consistently ("works on my system, dunno your problem")
+
+    ... so we load some part of numpy to see whether it'll do what needs to be done.  It's possible
+    that this simple test doesn't do neough to trigger the loading of custom optimized code, but we
+    can extend this unittest when we discover a shortfall.
+    """
 
     def test_shape(self):
+        """Simple test hoping to have enough coverage to trigger any additional module load"""
+
         a = numpy.arange(6)
         a2 = a[numpy.newaxis, :]
 
         self.assertIsNotNone(a2)
 
-        self.assertEqual(a2.shape, (1,6))
+        self.assertEqual(a2.shape, (1, 6))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pydantic_test.py
+++ b/pydantic_test.py
@@ -1,24 +1,60 @@
-import unittest
 from datetime import datetime
+from pydantic import BaseModel
 from typing import Tuple
 
-from pydantic import BaseModel
+import unittest
+
 
 class Delivery(BaseModel):
+    """A Delivery is a basic struct to trigger some schema behavior in Pydantic"""
+
     timestamp: datetime
     dimensions: Tuple[int, int]
 
 
-
 class DoesItEvenLoadPydanticTestCase(unittest.TestCase):
+    """A basic check that sufficient pydantic dependency is loaded to do basic work.
+
+    In past, Pydantic-Core has shown cross-platform, cross-version, and wheel issues, appearing as error messages such as:
+
+        No module named 'pydantic_core._pydantic_core'
+
+    This pops up even though the dependency is clearly present.  The key is looking at the resource
+    name: I only see "_<thing>" naming -- prefixed with an underscore("_") -- as cpython
+    compiled/optimized, typically backed by a shared object ("DLL", .dlsym,  or .so)
+
+    1. python setup assumes that the build platform is the run platform; this shows up when a
+        dependency tries to load some compiled/optimized component such as
+        `site-packages/pydantic_core/_pydantic_core.cpython-39-linux.so`
+    1.1. bulding on Mac, but running on linux, the loader looks for a
+        `site-packages/numpy/pydantic_core/_pydantic_core.cpython-39-linux.so` for there's only a
+        `site-packages/numpy/pydantic_core/_pydantic_core.cpython-39-darwin.so`
+    1.2. building on ARM HW but running on x86_64 linux, as was most of available AWS EC2, if
+        `_pydantic_core.cpython-39-linux.so` was found, the ARM .so didn't provide what the
+        x86-64 `ldd` needed
+    1.3. building on python-3.11, but running on python-3.9 or vice-versa, the loader searching for
+        `_pydantic_core.cpython-39-linux.so` would not see the `_pydantic_core.cpython-311-linux.so`
+        provided during build
+    2. module authors don't often have the awareness for cross-platform, or the hardware to check
+    3. Python setup is a great place to hide idiosyncrasies of your setup; this hidden logic is
+        hard to make work in cross-platform, cross-arch, or cross-version, and it doesn't fail
+        consistently ("works on my system, dunno your problem")
+
+    ... so we load some part of numpy to see whether it'll do what needs to be done.  It's possible
+    that this simple test doesn't do neough to trigger the loading of custom optimized code, but we
+    can extend this unittest when we discover a shortfall.
+    """
 
     def test_inference(self):
-        m = Delivery(timestamp='2020-01-02T03:04:05Z', dimensions=['10', '20'])
+        """Simple test hoping to have enough coverage to trigger any additional module load"""
+
+        m = Delivery(timestamp="2020-01-02T03:04:05Z", dimensions=["10", "20"])
 
         self.assertIsNotNone(m)
         self.assertIsNotNone(m.dimensions)
 
-        self.assertEqual(m.dimensions, (10,20))
+        self.assertEqual(m.dimensions, (10, 20))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -1,11 +1,12 @@
 # This is exactly https://github.com/bazelbuild/rules_python/blob/main/examples/pip_parse/test.py @018e355
 
 import unittest
-
 import main
 
 
 class ExampleTest(unittest.TestCase):
+    """This is a known-good unittest to confirm that Bazel py_test() is functional"""
+
     def test_main(self):
         self.assertEqual("2.25.1", main.version())
 


### PR DESCRIPTION
chore: activate pre-commit to catch avoidable errors, format and document code:
 - pre-commit configured for formatting, avoidable errors (schema, commits to master)
 - python code "blackened" and documented