### PR TITLE
chore: will matchManagers += bazel_dep enable automation?

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,8 @@
       "automerge": true,
       "enabled": true,
       "matchManagers": [
-        "bazel"
+        "bazel",
+        "bazel_dep"
       ],
       "matchUpdateTypes": [
         "patch",


### PR DESCRIPTION
This change attempts to enable auto merge for PRs such as #29 