### PR TITLE
chore: will matchManagers += bazel-module enable automation?

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,8 @@
       "enabled": true,
       "matchManagers": [
         "bazel",
-        "bazel_dep"
+        "bazel-module",
+        "pip_requirements"
       ],
       "matchUpdateTypes": [
         "patch",

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # rules_python_numpy
-Example of the pip_parse() issue with numpy
+Originally created to show a specific pip_parse() issue with numpy,this repo now acts as a simple
+demonstration of Munpy with Bazel and RenovateBot.
 
 ## linux requirements on Mac
 
-I develop mostlyon a Mac, but of course nVidia needs a linux env: I've been creating the linux-specific requirements using:
+I develop mostlyon a Mac, but of course nVidia needs a linux env: I've been creating the
+linux-specific requirements using:
 ```
 docker run --rm -it \
     -v ~/src/rules_python_numpy:/rules_python_numpy \


### PR DESCRIPTION
Looks like #30 didn't work out.

replacing with `bazel-module` per https://docs.renovatebot.com/modules/manager/bazel-module/